### PR TITLE
Add budget history graphs and UI tweaks

### DIFF
--- a/budgetApp/Views/Budget/BudgetHistoryChart.swift
+++ b/budgetApp/Views/Budget/BudgetHistoryChart.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+import Charts
+
+struct BudgetHistoryPoint: Identifiable {
+    let id = UUID()
+    let date: Date
+    let amount: Double
+}
+
+enum ChartMode: String, CaseIterable, Identifiable {
+    case spent
+    case remaining
+    var id: Self { self }
+    var title: String { self == .spent ? "Spent" : "Remaining" }
+}
+
+enum TimeRange: String, CaseIterable, Identifiable {
+    case currentMonth = "Month"
+    case past30d = "30d"
+    case threeM = "3m"
+    case sixM = "6m"
+    case year = "Year"
+    case all = "All"
+    var id: Self { self }
+    var title: String { rawValue }
+    var startDate: Date {
+        let cal = Calendar.current
+        switch self {
+        case .currentMonth:
+            let comps = cal.dateComponents([.year, .month], from: Date())
+            return cal.date(from: comps) ?? Date()
+        case .past30d:
+            return cal.date(byAdding: .day, value: -30, to: Date()) ?? Date()
+        case .threeM:
+            return cal.date(byAdding: .month, value: -3, to: Date()) ?? Date()
+        case .sixM:
+            return cal.date(byAdding: .month, value: -6, to: Date()) ?? Date()
+        case .year:
+            return cal.date(byAdding: .year, value: -1, to: Date()) ?? Date()
+        case .all:
+            return .distantPast
+        }
+    }
+}
+
+struct BudgetHistoryChart: View {
+    var category: CategoryItem
+    var purchases: [Purchase]
+    @State private var range: TimeRange = .currentMonth
+    @State private var mode: ChartMode = .spent
+
+    private var filtered: [Purchase] {
+        let start = range.startDate
+        return purchases.filter { $0.date >= start }
+    }
+
+    private var points: [BudgetHistoryPoint] {
+        let cal = Calendar.current
+        let sorted = filtered.sorted { $0.date < $1.date }
+        var running: Double = 0
+        var out: [BudgetHistoryPoint] = []
+        for p in sorted {
+            running += p.amount
+            let day = cal.startOfDay(for: p.date)
+            if let idx = out.firstIndex(where: { cal.isDate($0.date, inSameDayAs: day) }) {
+                out[idx] = BudgetHistoryPoint(date: day, amount: running)
+            } else {
+                out.append(BudgetHistoryPoint(date: day, amount: running))
+            }
+        }
+        return out
+    }
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Picker("Range", selection: $range) {
+                ForEach(TimeRange.allCases) { r in
+                    Text(r.title).tag(r)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            Picker("Mode", selection: $mode) {
+                ForEach(ChartMode.allCases) { m in
+                    Text(m.title).tag(m)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            Chart {
+                ForEach(points) { pt in
+                    LineMark(
+                        x: .value("Date", pt.date),
+                        y: .value(mode == .spent ? "Spent" : "Remaining",
+                                  mode == .spent ? pt.amount : max(category.limit - pt.amount, 0))
+                    )
+                }
+            }
+            .frame(height: 200)
+        }
+        .padding(.vertical)
+    }
+}

--- a/budgetApp/Views/Budget/BudgetSubviews.swift
+++ b/budgetApp/Views/Budget/BudgetSubviews.swift
@@ -30,9 +30,10 @@ struct BudgetProgressCard: View {
             cornerRadius: cornerRadius,
             editing: editing,
             wiggle: false,                // no jiggle
-            background: .cardBackground,  // solid, no flashing
+            background: .cardBackground,  // solid, base color
             overlayStroke: strokeColor,
-            dashedWhenEditing: true       // pulse between dashed and solid while moving
+            dashedWhenEditing: true,      // pulse between dashed and solid while moving
+            pulseBackgroundWhenEditing: true
         ) {
             VStack(alignment: .leading, spacing: 10) {
                 HStack {
@@ -136,16 +137,8 @@ struct CategoryEditorSheet: View {
                         }
                         .accessibilityHidden(true)
 
-                        VStack(alignment: .leading) {
-                            TextField("SF Symbol (e.g. tag.fill, cart.fill)", text: $iconSystemName)
-                                .textInputAutocapitalization(.never)
-                                .autocorrectionDisabled(true)
-                                .font(.subheadline)
-                            Text("Use any valid SF Symbol name.").font(.caption).foregroundColor(.secondary)
-                        }
+                        ColorPicker("Icon Color", selection: $colorSelection, supportsOpacity: false)
                     }
-
-                    ColorPicker("Icon Color", selection: $colorSelection, supportsOpacity: false)
 
                     Menu("Quick Symbols") {
                         ForEach(["tag.fill", "cart.fill", "fork.knife", "airplane", "car.fill", "tram.fill", "popcorn.fill", "bag.fill", "house.fill", "stethoscope", "bolt.fill"], id: \.self) { s in

--- a/budgetApp/Views/Budget/PurchaseListView.swift
+++ b/budgetApp/Views/Budget/PurchaseListView.swift
@@ -41,6 +41,12 @@ struct PurchaseListView: View {
 
     var body: some View {
         List {
+            if case .category(let cat) = filter {
+                Section {
+                    BudgetHistoryChart(category: cat, purchases: purchases)
+                }
+            }
+
             ForEach(purchases) { p in
                 VStack(alignment: .leading, spacing: 4) {
                     let cat = store.categories.first(where: { $0.id == p.categoryID })

--- a/budgetApp/Views/Shared/TileCard.swift
+++ b/budgetApp/Views/Shared/TileCard.swift
@@ -15,17 +15,26 @@ struct TileCard<Content: View>: View {
     var overlayStroke: Color = .subtleOutline
     /// When true, the border will pulse between dashed and solid while `editing` is true.
     var dashedWhenEditing: Bool = false
+    /// When true, the background will pulse between a light gray and white while editing.
+    var pulseBackgroundWhenEditing: Bool = false
     var content: () -> Content
 
     @State private var dashedVisible: Bool = false
+    @State private var bgPulse: Bool = false
 
     private var showPulse: Bool { editing && dashedWhenEditing }
+    private var showBgPulse: Bool { editing && pulseBackgroundWhenEditing }
 
     var body: some View {
         ZStack {
             // Background
             RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
                 .fill(background)
+
+            if showBgPulse {
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(Color.gray.opacity(bgPulse ? 0.0 : 0.2))
+            }
 
             // Border: crossfade between solid and dashed
             ZStack {
@@ -49,8 +58,12 @@ struct TileCard<Content: View>: View {
             content()
                 .padding(14)
         }
-        .onAppear { handlePulseChange(active: showPulse) }
+        .onAppear {
+            handlePulseChange(active: showPulse)
+            handleBgPulseChange(active: showBgPulse)
+        }
         .onChange(of: showPulse) { active in handlePulseChange(active: active) }
+        .onChange(of: showBgPulse) { active in handleBgPulseChange(active: active) }
         .frame(width: size.width, height: size.height)
         .contentShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
     }
@@ -67,6 +80,19 @@ struct TileCard<Content: View>: View {
         } else {
             // Stop pulsing, show solid
             dashedVisible = false
+        }
+    }
+
+    private func handleBgPulseChange(active: Bool) {
+        if active {
+            bgPulse = false
+            DispatchQueue.main.async {
+                withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
+                    bgPulse = true
+                }
+            }
+        } else {
+            bgPulse = false
         }
     }
 }


### PR DESCRIPTION
## Summary
- add pulsing gray background to budget tiles while moving
- show spending history charts on budget detail pages with range and mode controls
- streamline category editor appearance by using color picker with icon preview and quick symbol menu

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_689d46946ffc8328a0f7eb566ac45711