### PR TITLE
feat: add toggleable ChatGPT debug overlay

### DIFF
--- a/budgetApp/ChatGPTService.swift
+++ b/budgetApp/ChatGPTService.swift
@@ -168,7 +168,7 @@ final class ChatGPTService {
             let status = (response as? HTTPURLResponse)?.statusCode ?? -1
             stamp("HTTP status=\(status)")
             let raw = String(data: data, encoding: .utf8) ?? "<non-utf8 response>"
-            stamp("Raw response (first 800 chars):\n\(raw.prefix(800))")
+            stamp("Raw response:\n\(raw)")
             guard (200...299).contains(status) else { throw URLError(.badServerResponse) }
 
             let api = try JSONDecoder().decode(ChatAPIResponse.self, from: data)
@@ -281,7 +281,7 @@ final class ChatGPTService {
             let status = (response as? HTTPURLResponse)?.statusCode ?? -1
             stamp("HTTP status=\(status)")
             let raw = String(data: data, encoding: .utf8) ?? "<non-utf8 response>"
-            stamp("Raw response (first 800 chars):\n\(raw.prefix(800))")
+            stamp("Raw response:\n\(raw)")
             guard (200...299).contains(status) else { throw URLError(.badServerResponse) }
 
             let api = try JSONDecoder().decode(ChatAPIResponse.self, from: data)

--- a/budgetApp/Debug/DebugConsole.swift
+++ b/budgetApp/Debug/DebugConsole.swift
@@ -1,5 +1,5 @@
 // File: BudgetApp/Debug/DebugConsole.swift
-// Collapsible on-screen console for temporary diagnostics.
+// Full-screen expandable console for ChatGPT diagnostics.
 
 import SwiftUI
 import UIKit
@@ -7,40 +7,55 @@ import UIKit
 struct DebugConsoleView: View {
     var title: String = "Debug Console"
     @Binding var lines: [String]
-    @State private var isExpanded: Bool = true
+    @State private var isPresented: Bool = false
 
     private var combined: String {
         lines.joined(separator: "\n")
     }
 
     var body: some View {
-        VStack(spacing: 8) {
-            DisclosureGroup(isExpanded ? "\(title) (tap to hide)" : "\(title) (tap to show)", isExpanded: $isExpanded) {
+        Button {
+            isPresented = true
+        } label: {
+            Label("ChatGPT Debug Output", systemImage: "ladybug")
+                .font(.footnote)
+                .padding(6)
+                .background(Capsule().fill(Color.gray.opacity(0.2)))
+        }
+        .buttonStyle(.plain)
+        .fullScreenCover(isPresented: $isPresented) {
+            NavigationStack {
                 ScrollView {
                     Text(combined.isEmpty ? "— no logs yet —" : combined)
                         .textSelection(.enabled)
                         .font(.footnote.monospaced())
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.top, 4)
+                        .padding()
                 }
-                .frame(minHeight: 100, maxHeight: 220)
-                HStack(spacing: 12) {
-                    Button("Copy") {
-                        UIPasteboard.general.string = combined
+                .navigationTitle(title)
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button {
+                            isPresented = false
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .font(.title)
+                        }
                     }
-                    Button("Clear") {
-                        lines.removeAll()
+                    ToolbarItem(placement: .bottomBar) {
+                        HStack(spacing: 20) {
+                            Button("Copy") {
+                                UIPasteboard.general.string = combined
+                            }
+                            Button("Clear") {
+                                lines.removeAll()
+                            }
+                        }
+                        .font(.footnote)
                     }
-                    Spacer()
                 }
-                .font(.footnote)
-                .padding(.top, 4)
             }
-            .font(.headline)
-            // removed global purple tint here
         }
-        .padding(.horizontal)
-        .padding(.top, 6)
     }
 }
 

--- a/budgetApp/Views/AddPurchaseSheet.swift
+++ b/budgetApp/Views/AddPurchaseSheet.swift
@@ -55,6 +55,7 @@ struct AddPurchaseSheet: View {
 
     @State private var showTagPickerForDraftID: UUID?
     @State private var debugLines: [String] = []
+    @AppStorage("chatGPTDebugEnabled") private var chatGPTDebugEnabled = false
 
     var body: some View {
         NavigationStack {
@@ -147,7 +148,9 @@ struct AddPurchaseSheet: View {
                         }
                     }
 
-                    DebugConsoleView(title: "ChatGPT Debug (Add Purchase)", lines: $debugLines)
+                    if chatGPTDebugEnabled {
+                        DebugConsoleView(title: "ChatGPT Debug (Add Purchase)", lines: $debugLines)
+                    }
                 }
                 .padding()
             }
@@ -182,6 +185,7 @@ struct AddPurchaseSheet: View {
     }
 
     private func log(_ s: String) {
+        guard chatGPTDebugEnabled else { return }
         let f = DateFormatter(); f.dateFormat = "HH:mm:ss.SSS"
         debugLines.append("\(f.string(from: Date())) \(s)")
         if debugLines.count > 400 { debugLines.removeFirst(debugLines.count - 400) }

--- a/budgetApp/Views/Cards/CardsView.swift
+++ b/budgetApp/Views/Cards/CardsView.swift
@@ -19,6 +19,7 @@ struct CardsView: View {
     @State private var selectedCategoryID: UUID?
     
     @State private var debugLines: [String] = []
+    @AppStorage("chatGPTDebugEnabled") private var chatGPTDebugEnabled = false
     
     @State private var cardsEditingMode = false
     @State private var cardsWiggleOn = false
@@ -121,7 +122,9 @@ struct CardsView: View {
                 )
                 .environmentObject(store)
                 
-                DebugConsoleView(title: "ChatGPT Debug (Cards)", lines: $debugLines)
+                if chatGPTDebugEnabled {
+                    DebugConsoleView(title: "ChatGPT Debug (Cards)", lines: $debugLines)
+                }
             }
             .padding(.vertical)
         }
@@ -155,6 +158,7 @@ struct CardsView: View {
     }
     
     private func log(_ s: String) {
+        guard chatGPTDebugEnabled else { return }
         let f = DateFormatter(); f.dateFormat = "HH:mm:ss.SSS"
         debugLines.append("\(f.string(from: Date())) \(s)")
         if debugLines.count > 400 { debugLines.removeFirst(debugLines.count - 400) }

--- a/budgetApp/Views/SettingsSheet.swift
+++ b/budgetApp/Views/SettingsSheet.swift
@@ -9,6 +9,7 @@ struct SettingsSheet: View {
     @EnvironmentObject var store: AppStore
 
     @State private var showEraseConfirm = false
+    @AppStorage("chatGPTDebugEnabled") private var chatGPTDebugEnabled = false
 
     private let swatches: [Color] = [
         Color(hex: "#7F3DFF") ?? .purple,
@@ -73,6 +74,12 @@ struct SettingsSheet: View {
                     } label: {
                         Label("Clear Purchases & Reset Budgets", systemImage: "trash")
                     }
+                }
+
+                Section {
+                    Toggle("ChatGPT debug output", isOn: $chatGPTDebugEnabled)
+                } header: {
+                    Text("Developer Settings").foregroundColor(.gray)
                 }
             }
             .navigationTitle("Settings")


### PR DESCRIPTION
## Summary
- add full-screen ChatGPT debug overlay with copy and clear options
- log complete ChatGPT responses
- allow enabling ChatGPT debug output from new Developer Settings section

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689d4bd3dc548328b601b6fe42e067b3