### PR TITLE
Add ChatGPT API key field in settings

### DIFF
--- a/budgetApp/ChatGPTService.swift
+++ b/budgetApp/ChatGPTService.swift
@@ -79,6 +79,16 @@ final class ChatGPTService {
 
     private let logger = Logger(subsystem: "BudgetApp", category: "ChatGPTService")
 
+    private func addAuth(to request: inout URLRequest, log stamp: (String)->Void) {
+        if let stored = UserDefaults.standard.string(forKey: "chatgpt_api_key"), !stored.isEmpty {
+            request.addValue("Bearer \(stored)", forHTTPHeaderField: "Authorization"); stamp("Auth: using API key from settings")
+        } else if let key = ProcessInfo.processInfo.environment["OPENAI_API_KEY"], !key.isEmpty {
+            request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization"); stamp("Auth: using API key from environment")
+        } else {
+            stamp("ERROR: OPENAI_API_KEY not found in environment or settings. Set it in Settings or Scheme > Run > Environment Variables.")
+        }
+    }
+
     // MARK: - Single result (kept for planner text flow)
     func analyze(
         image: UIImage? = nil,
@@ -153,9 +163,7 @@ final class ChatGPTService {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        if let key = ProcessInfo.processInfo.environment["OPENAI_API_KEY"], !key.isEmpty {
-            request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization"); stamp("Auth: using API key from environment")
-        } else { stamp("ERROR: OPENAI_API_KEY not found in environment. Set it in Scheme > Run > Environment Variables.") }
+        addAuth(to: &request, log: stamp)
 
         do {
             let body = try JSONSerialization.data(withJSONObject: payload)
@@ -266,9 +274,7 @@ final class ChatGPTService {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        if let key = ProcessInfo.processInfo.environment["OPENAI_API_KEY"], !key.isEmpty {
-            request.addValue("Bearer \(key)", forHTTPHeaderField: "Authorization"); stamp("Auth: using API key from environment")
-        } else { stamp("ERROR: OPENAI_API_KEY not found in environment. Set it in Scheme > Run > Environment Variables.") }
+        addAuth(to: &request, log: stamp)
 
         do {
             let body = try JSONSerialization.data(withJSONObject: payload)

--- a/budgetApp/Views/SettingsSheet.swift
+++ b/budgetApp/Views/SettingsSheet.swift
@@ -9,6 +9,7 @@ struct SettingsSheet: View {
     @EnvironmentObject var store: AppStore
 
     @State private var showEraseConfirm = false
+    @AppStorage("chatgpt_api_key") private var chatGPTKey: String = ""
 
     private let swatches: [Color] = [
         Color(hex: "#7F3DFF") ?? .purple,
@@ -65,6 +66,12 @@ struct SettingsSheet: View {
                     Text("Accent color applies to generic controls and icons that don't have their own category color.")
                         .font(.footnote)
                         .foregroundColor(.secondary)
+                }
+
+                Section(header: Text("ChatGPT")) {
+                    TextField("ChatGPT API Key", text: $chatGPTKey)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
                 }
 
                 Section(header: Text("Data")) {


### PR DESCRIPTION
## Summary
- Allow users to supply a ChatGPT API key in Settings
- Prefer the saved key over `OPENAI_API_KEY` when authorizing requests

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d4cc8ef70832892073e8a505253da