### PR TITLE
Add Plaid account linking

### DIFF
--- a/budgetApp.xcodeproj/project.pbxproj
+++ b/budgetApp.xcodeproj/project.pbxproj
@@ -26,7 +26,8 @@
 		B1CEDE552E483C78003A0BBC /* AppAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1CEDE542E483C78003A0BBC /* AppAppearance.swift */; };
 		B1CEDE572E483C8B003A0BBC /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1CEDE562E483C8B003A0BBC /* Models.swift */; };
 		B1CEDE592E483CC4003A0BBC /* AppStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1CEDE582E483CC4003A0BBC /* AppStore.swift */; };
-		B1CEDE5B2E483CD1003A0BBC /* ChatGPTService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1CEDE5A2E483CD1003A0BBC /* ChatGPTService.swift */; };
+B1CEDE5B2E483CD1003A0BBC /* ChatGPTService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1CEDE5A2E483CD1003A0BBC /* ChatGPTService.swift */; };
+B1FAF1A12E60000100A0BBCD /* PlaidService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FAF1A02E60000100A0BBCD /* PlaidService.swift */; };
 		B1CEDE5D2E483CED003A0BBC /* SettingsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1CEDE5C2E483CED003A0BBC /* SettingsSheet.swift */; };
 		B1CEDE612E483E87003A0BBC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B1CEDE602E483E87003A0BBC /* Assets.xcassets */; };
 		B1CEDE632E483F6B003A0BBC /* BudgetAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1CEDE622E483F6B003A0BBC /* BudgetAppApp.swift */; };
@@ -74,8 +75,9 @@
 		B1CEDE542E483C78003A0BBC /* AppAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppAppearance.swift; path = BudgetApp/AppAppearance.swift; sourceTree = SOURCE_ROOT; };
 		B1CEDE562E483C8B003A0BBC /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Models.swift; path = BudgetApp/Models.swift; sourceTree = SOURCE_ROOT; };
 		B1CEDE582E483CC4003A0BBC /* AppStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppStore.swift; path = BudgetApp/AppStore.swift; sourceTree = SOURCE_ROOT; };
-		B1CEDE5A2E483CD1003A0BBC /* ChatGPTService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ChatGPTService.swift; path = BudgetApp/ChatGPTService.swift; sourceTree = SOURCE_ROOT; };
-		B1CEDE5C2E483CED003A0BBC /* SettingsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SettingsSheet.swift; path = BudgetApp/Views/SettingsSheet.swift; sourceTree = SOURCE_ROOT; };
+B1CEDE5A2E483CD1003A0BBC /* ChatGPTService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ChatGPTService.swift; path = BudgetApp/ChatGPTService.swift; sourceTree = SOURCE_ROOT; };
+B1FAF1A02E60000100A0BBCD /* PlaidService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PlaidService.swift; path = budgetApp/PlaidService.swift; sourceTree = SOURCE_ROOT; };
+B1CEDE5C2E483CED003A0BBC /* SettingsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SettingsSheet.swift; path = BudgetApp/Views/SettingsSheet.swift; sourceTree = SOURCE_ROOT; };
 		B1CEDE602E483E87003A0BBC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B1CEDE622E483F6B003A0BBC /* BudgetAppApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BudgetAppApp.swift; sourceTree = "<group>"; };
                 B1CEDE652E4840C4003A0BBC /* TileCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TileCard.swift; path = BudgetApp/Views/Shared/TileCard.swift; sourceTree = SOURCE_ROOT; };
@@ -137,18 +139,19 @@
 		};
 		B1CEDDF72E47C71A003A0BBC /* budgetApp */ = {
 			isa = PBXGroup;
-			children = (
-				B15974422E490FC100E7D322 /* Debug */,
-				B1CEDE622E483F6B003A0BBC /* BudgetAppApp.swift */,
-				B1CEDE5F2E483DFF003A0BBC /* Preview Content */,
-				B1CEDE2D2E47CEE3003A0BBC /* Views */,
-				B1CEDE2A2E47CEBF003A0BBC /* Logic */,
-				B1CEDE542E483C78003A0BBC /* AppAppearance.swift */,
-				B1CEDE562E483C8B003A0BBC /* Models.swift */,
-				B1CEDE582E483CC4003A0BBC /* AppStore.swift */,
-				B1CEDE5A2E483CD1003A0BBC /* ChatGPTService.swift */,
-				B1CEDE602E483E87003A0BBC /* Assets.xcassets */,
-			);
+                        children = (
+                                B15974422E490FC100E7D322 /* Debug */,
+                                B1CEDE622E483F6B003A0BBC /* BudgetAppApp.swift */,
+                                B1CEDE5F2E483DFF003A0BBC /* Preview Content */,
+                                B1CEDE2D2E47CEE3003A0BBC /* Views */,
+                                B1CEDE2A2E47CEBF003A0BBC /* Logic */,
+                                B1CEDE542E483C78003A0BBC /* AppAppearance.swift */,
+                                B1CEDE562E483C8B003A0BBC /* Models.swift */,
+                                B1CEDE582E483CC4003A0BBC /* AppStore.swift */,
+                                B1CEDE5A2E483CD1003A0BBC /* ChatGPTService.swift */,
+                                B1FAF1A02E60000100A0BBCD /* PlaidService.swift */,
+                                B1CEDE602E483E87003A0BBC /* Assets.xcassets */,
+                        );
 			path = budgetApp;
 			sourceTree = "<group>";
 		};
@@ -371,15 +374,16 @@
 				B1CEDE512E483C26003A0BBC /* Recommenders.swift in Sources */,
 				B1CEDE5D2E483CED003A0BBC /* SettingsSheet.swift in Sources */,
 				B1CEDE462E483BE7003A0BBC /* BudgetSubviews.swift in Sources */,
-				B1CEDE5B2E483CD1003A0BBC /* ChatGPTService.swift in Sources */,
-				B1CEDE4A2E483BF3003A0BBC /* CameraPicker.swift in Sources */,
-				B1CEDE402E483BC7003A0BBC /* RootView.swift in Sources */,
-				B1CEDE482E483BEF003A0BBC /* AddPurchaseSheet.swift in Sources */,
+                                B1CEDE5B2E483CD1003A0BBC /* ChatGPTService.swift in Sources */,
+                                B1CEDE4A2E483BF3003A0BBC /* CameraPicker.swift in Sources */,
+                                B1CEDE402E483BC7003A0BBC /* RootView.swift in Sources */,
+                                B1CEDE482E483BEF003A0BBC /* AddPurchaseSheet.swift in Sources */,
                             B1CEDE442E483BDF003A0BBC /* PurchaseEditorSheet.swift in Sources */,
                             951EC15A502843B0BC16125A /* TagPickerSheet.swift in Sources */,
                             37AF2F3569E04D5FA53E13A4 /* PurchaseListView.swift in Sources */,
                             B1D0EAD22E500000003A0BBD /* DuplicateReviewSheet.swift in Sources */,
-                    );
+                            B1FAF1A12E60000100A0BBCD /* PlaidService.swift in Sources */,
+                        );
                     runOnlyForDeploymentPostprocessing = 0;
                 };
 		B1CEDE012E47C71B003A0BBC /* Sources */ = {

--- a/budgetApp/PlaidService.swift
+++ b/budgetApp/PlaidService.swift
@@ -1,0 +1,77 @@
+import Foundation
+import LinkKit
+import UIKit
+
+final class PlaidService {
+    static let shared = PlaidService()
+    private init() {}
+
+    private var handler: Handler?
+
+    func linkAccount() {
+        Task {
+            do {
+                let token = try await createLinkToken()
+                await MainActor.run {
+                    var configuration = LinkTokenConfiguration(token: token) { success in
+                        Task { await self.exchangePublicToken(success.publicToken) }
+                    }
+                    configuration.onExit = { _ in }
+                    self.handler = Plaid.create(configuration: configuration)
+                    if let top = UIApplication.shared.topViewController() {
+                        self.handler?.open(presentUsing: .viewController(top))
+                    }
+                }
+            } catch {
+                print("Plaid link error: \(error)")
+            }
+        }
+    }
+
+    private func createLinkToken() async throws -> String {
+        guard let url = URL(string: "http://localhost:8000/api/plaid/create_link_token") else {
+            throw URLError(.badURL)
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        let (data, _) = try await URLSession.shared.data(for: request)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        if let token = json?["link_token"] as? String {
+            return token
+        } else {
+            throw URLError(.badServerResponse)
+        }
+    }
+
+    private func exchangePublicToken(_ publicToken: String) async {
+        guard let url = URL(string: "http://localhost:8000/api/plaid/set_access_token") else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: ["public_token": publicToken])
+        do {
+            _ = try await URLSession.shared.data(for: request)
+        } catch {
+            print("Exchange public token failed: \(error)")
+        }
+    }
+}
+
+private extension UIApplication {
+    func topViewController(base: UIViewController? = UIApplication.shared.connectedScenes
+        .compactMap { ($0 as? UIWindowScene)?.keyWindow }.first?.rootViewController) -> UIViewController? {
+        if let nav = base as? UINavigationController {
+            return topViewController(base: nav.visibleViewController)
+        }
+        if let tab = base as? UITabBarController {
+            if let selected = tab.selectedViewController {
+                return topViewController(base: selected)
+            }
+        }
+        if let presented = base?.presentedViewController {
+            return topViewController(base: presented)
+        }
+        return base
+    }
+}

--- a/budgetApp/Views/SettingsSheet.swift
+++ b/budgetApp/Views/SettingsSheet.swift
@@ -75,6 +75,14 @@ struct SettingsSheet: View {
                         .autocorrectionDisabled()
                 }
 
+                Section(header: Text("Banking")) {
+                    Button {
+                        PlaidService.shared.linkAccount()
+                    } label: {
+                        Label("Link Account with Plaid", systemImage: "link")
+                    }
+                }
+
                 Section(header: Text("Data")) {
                     Button(role: .destructive) {
                         showEraseConfirm = true


### PR DESCRIPTION
## Summary
- integrate Plaid Link using LinkKit and backend endpoints
- add PlaidService for link token creation and public token exchange
- expose a "Link Account with Plaid" button on Settings

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild test -project budgetApp.xcodeproj -scheme budgetApp -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ac777ef483289c04bd99a03f66db